### PR TITLE
Fixes Fastboot warning

### DIFF
--- a/addon/components/twitter-entity/hashtag.js
+++ b/addon/components/twitter-entity/hashtag.js
@@ -1,8 +1,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import jQuery from 'jquery';
 import layout from '../../templates/components/twitter-entity/hashtag';
-const { param } = jQuery;
+
 
 export default Component.extend({
   layout,
@@ -10,7 +9,6 @@ export default Component.extend({
 
   href: computed(function() {
     const hashtag = this.get('entity.text');
-    const params = param({ q: `#${hashtag}` });
-    return `https://twitter.com/search?${params}`;
+    return `https://twitter.com/search?q=%23${encodeURI(hashtag)}`;
   })
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,10 +297,6 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
@@ -1976,7 +1972,7 @@ ember-cli-babel@6.6.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.3.0:
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.7:
+ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.3:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
   dependencies:
@@ -2289,12 +2285,6 @@ ember-disable-proxy-controllers@1.0.1:
   resolved "https://registry.yarnpkg.com/ember-disable-proxy-controllers/-/ember-disable-proxy-controllers-1.0.1.tgz#1254eeec0ba025c24eb9e8da611afa7b38754281"
   dependencies:
     ember-cli-babel "^5.0.0"
-
-ember-improved-cp@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/ember-improved-cp/-/ember-improved-cp-0.0.0.tgz#e7fbbed9890ad1c03ab288a4316b190f8cbf6d5a"
-  dependencies:
-    ember-cli-babel "^5.1.7"
 
 ember-load-initializers@1.0.0:
   version "1.0.0"
@@ -4490,20 +4480,11 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"


### PR DESCRIPTION
The use of jQuery in this addon was causing a warning to be displayed in Fastboot. This PR: 

- Removes the unnecessary dependency on jQuery 
- Uses simple string interpolation to produce the hashtag href